### PR TITLE
Reject static methods when searching for model relationships

### DIFF
--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -31,7 +31,7 @@ class RelationFinder
         $methods = Collection::make($class->getMethods(ReflectionMethod::IS_PUBLIC))
             ->merge($traitMethods)
             ->reject(function (ReflectionMethod $method) use ($model) {
-                return $method->class !== $model || $method->getNumberOfParameters() > 0;
+                return $method->class !== $model || $method->getNumberOfParameters() > 0 || $method->isStatic();;
             });
 
         $relations = Collection::make();


### PR DESCRIPTION
This PR includes a fix for an issue encountered when using Scout in Laravel, reported as issue #59.

The problem is that the RelationshipFinder class invokes each public, 0-param method on all of the models found in order to collect relationship information. Scout's Searchable trait includes a destructive, 0-param static method removeAllFromSearch that removes all models from the index.

This fix rejects all static methods from testing for relationships. Since Eloquent relationship information should all be defined as non-static methods, this should not affect current model generation but should help eliminate accidentally calling destructive methods on a model.